### PR TITLE
Remove Makefiles (unnecessary with new cgo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ INSTALL:
   To experiment with go-webkit, you can just compile and run the example
   program:
 
-    make install
-    make example
-    ./example/webview
+    go run example/webview.go
 
 LICENSE:
 --------

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,6 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG     = webview
-GOFILES = webview.go
-
-include $(GOROOT)/src/Make.cmd

--- a/webkit/Makefile
+++ b/webkit/Makefile
@@ -1,6 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG     = github.com/mattn/go-webkit/webkit
-CGOFILES = webkit.go
-
-include $(GOROOT)/src/Make.pkg


### PR DESCRIPTION
I believe that the Makefiles are no longer necessary with cgo. If I just run `go run example/webview.go`, the application opens.
